### PR TITLE
Add metadata columns and audio playback in report

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,17 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.x'
+    - run: pip install -r requirements.txt
+    - run: pytest
+

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The application uses a dark themed PySimpleGUI interface and can be turned into 
    ```bash
    pip install -r requirements.txt
    ```
-2. Provide API credentials via environment variables:
+2. Provide API credentials via environment variables or the GUI settings dialog:
    - `SPOTIPY_CLIENT_ID`
    - `SPOTIPY_CLIENT_SECRET`
    - `SPOTIPY_REDIRECT_URI`
@@ -20,6 +20,8 @@ The application uses a dark themed PySimpleGUI interface and can be turned into 
    ```bash
    python src/main.py
    ```
+   Use the **Settings** button in the GUI to enter credentials if you have not
+   set the environment variables. Values are saved to `~/.mp3organizer_config`.
 
 To build a standalone executable on Windows:
 ```bash
@@ -53,6 +55,7 @@ src/
 - Duplicate tracks are skipped and Spotify playlists split every 10,000 songs.
 - ID3 tags and filenames are corrected when recognized through audD.
 - A progress bar shows percentage and estimated remaining time.
+
 - Generates an HTML report of processed files including album, year and genre
   metadata, and allows audio preview directly in the browser.
 
@@ -62,3 +65,15 @@ After processing, a `report.html` file is created in the output folder. It lists
 each track with artist, title, album, year, genre and the destination folder.
 Every row also contains an embedded audio player so the resulting files can be
 played without leaving the browser.
+
+- Generates an HTML report of processed files.
+
+## Running Tests
+
+Install the dependencies and execute `pytest` from the project root:
+
+```bash
+pip install -r requirements.txt
+pytest
+```
+

--- a/README.md
+++ b/README.md
@@ -53,4 +53,12 @@ src/
 - Duplicate tracks are skipped and Spotify playlists split every 10,000 songs.
 - ID3 tags and filenames are corrected when recognized through audD.
 - A progress bar shows percentage and estimated remaining time.
-- Generates an HTML report of processed files.
+- Generates an HTML report of processed files including album, year and genre
+  metadata, and allows audio preview directly in the browser.
+
+### HTML Report
+
+After processing, a `report.html` file is created in the output folder. It lists
+each track with artist, title, album, year, genre and the destination folder.
+Every row also contains an embedded audio player so the resulting files can be
+played without leaving the browser.

--- a/mp3organizer/audd.py
+++ b/mp3organizer/audd.py
@@ -1,9 +1,18 @@
+import os
 import requests
 
+from .utils import load_config
 
-def recognize(path: str, api_key: str):
-    files = {'file': open(path, 'rb')}
-    data = {'api_token': api_key}
+
+def recognize(path: str, api_key: str | None = None):
+    api_key = api_key or os.getenv("AUDD_API_KEY")
+    if not api_key:
+        cfg = load_config()
+        api_key = cfg.get("AUDD_API_KEY")
+    if not api_key:
+        return None, None
+    files = {"file": open(path, "rb")}
+    data = {"api_token": api_key}
     r = requests.post('https://api.audd.io/', data=data, files=files)
     if r.status_code == 200:
         result = r.json().get('result')

--- a/mp3organizer/core.py
+++ b/mp3organizer/core.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 from typing import Optional
 
@@ -76,22 +75,20 @@ def process(src: Path, dst: Path, window: Optional[object] = None):
             if not match:
                 match = fuzzy_search(sp, cache, f'{artist} {title}', on_wait=on_wait)
         if not match:
-            api_key = os.getenv('AUDD_API_KEY')
-            if api_key:
-                ra, rt = recognize(str(file), api_key)
-                if ra and rt:
-                    match = search(sp, cache, ra, rt, on_wait=on_wait)
-                    if not match:
-                        match = fuzzy_search(sp, cache, f'{ra} {rt}', on_wait=on_wait)
-                    artist = ra
-                    title = rt
-                    try:
-                        tags = EasyID3(file)
-                    except ID3NoHeaderError:
-                        tags = EasyID3()
-                    tags['artist'] = artist.title()
-                    tags['title'] = title.title()
-                    tags.save(file)
+            ra, rt = recognize(str(file))
+            if ra and rt:
+                match = search(sp, cache, ra, rt, on_wait=on_wait)
+                if not match:
+                    match = fuzzy_search(sp, cache, f'{ra} {rt}', on_wait=on_wait)
+                artist = ra
+                title = rt
+                try:
+                    tags = EasyID3(file)
+                except ID3NoHeaderError:
+                    tags = EasyID3()
+                tags['artist'] = artist.title()
+                tags['title'] = title.title()
+                tags.save(file)
 
         if match:
             track_id = match['id']
@@ -137,3 +134,4 @@ def process(src: Path, dst: Path, window: Optional[object] = None):
 
     write_html_report(entries, dst / 'report.html')
     save_cache(cache)
+

--- a/mp3organizer/core.py
+++ b/mp3organizer/core.py
@@ -57,8 +57,12 @@ def process(src: Path, dst: Path, window: Optional[object] = None):
             tags = EasyID3(file)
             artist = tags.get('artist', [None])[0]
             title = tags.get('title', [None])[0]
+            album = tags.get('album', [''])[0]
+            year = tags.get('date', [''])[0]
+            genre = tags.get('genre', [''])[0]
         except ID3NoHeaderError:
             artist = title = None
+            album = year = genre = ''
 
         if not artist or not title:
             parts = file.stem.split('-')
@@ -97,14 +101,36 @@ def process(src: Path, dst: Path, window: Optional[object] = None):
             dest_name = sanitize_filename(f"{artist} - {title}") + file.suffix
             dest = spotify_dir / dest_name
             file.rename(dest)
-            entries.append({'artist': artist or '', 'title': title or '', 'dest': 'Spotify'})
+            rel_path = dest.relative_to(dst)
+            entries.append(
+                {
+                    'artist': artist or '',
+                    'title': title or '',
+                    'album': album,
+                    'year': year,
+                    'genre': genre,
+                    'dest': 'Spotify',
+                    'path': str(rel_path),
+                }
+            )
         else:
             dest_name = sanitize_filename(file.stem) + file.suffix
             dest = napster_dir / dest_name
             file.rename(dest)
             with open(napster_playlist, 'a', encoding='utf-8') as m3u:
                 m3u.write(dest.name + '\n')
-            entries.append({'artist': artist or '', 'title': title or '', 'dest': 'Napster'})
+            rel_path = dest.relative_to(dst)
+            entries.append(
+                {
+                    'artist': artist or '',
+                    'title': title or '',
+                    'album': album,
+                    'year': year,
+                    'genre': genre,
+                    'dest': 'Napster',
+                    'path': str(rel_path),
+                }
+            )
 
         if window:
             window.refresh()

--- a/mp3organizer/gui.py
+++ b/mp3organizer/gui.py
@@ -2,6 +2,7 @@ from pathlib import Path
 import PySimpleGUI as sg
 
 from .core import process
+from .utils import load_config, save_config
 
 
 def main():
@@ -9,12 +10,36 @@ def main():
     layout = [
         [sg.Text('Source Folder'), sg.Input(key='SRC'), sg.FolderBrowse()],
         [sg.Text('Output Folder'), sg.Input(key='DST'), sg.FolderBrowse()],
-        [sg.Button('Start')],
+        [sg.Button('Start'), sg.Button('Settings')],
         [sg.ProgressBar(max_value=1, orientation='h', size=(40, 20), key='PROG')],
         [sg.Text('', size=(60, 1), key='STATUS')],
     ]
 
     window = sg.Window('MP3 Organizer', layout, finalize=True)
+
+    def show_settings():
+        cfg = load_config()
+        layout = [
+            [sg.Text('SPOTIPY_CLIENT_ID'), sg.Input(cfg.get('SPOTIPY_CLIENT_ID', ''), key='CID')],
+            [sg.Text('SPOTIPY_CLIENT_SECRET'), sg.Input(cfg.get('SPOTIPY_CLIENT_SECRET', ''), key='SECRET')],
+            [sg.Text('SPOTIPY_REDIRECT_URI'), sg.Input(cfg.get('SPOTIPY_REDIRECT_URI', ''), key='REDIRECT')],
+            [sg.Text('AUDD_API_KEY'), sg.Input(cfg.get('AUDD_API_KEY', ''), key='AUDD')],
+            [sg.Button('Save'), sg.Button('Cancel')],
+        ]
+        win = sg.Window('Settings', layout, modal=True)
+        while True:
+            e, v = win.read()
+            if e in (sg.WIN_CLOSED, 'Cancel'):
+                break
+            if e == 'Save':
+                save_config({
+                    'SPOTIPY_CLIENT_ID': v['CID'],
+                    'SPOTIPY_CLIENT_SECRET': v['SECRET'],
+                    'SPOTIPY_REDIRECT_URI': v['REDIRECT'],
+                    'AUDD_API_KEY': v['AUDD'],
+                })
+                break
+        win.close()
 
     while True:
         event, values = window.read()
@@ -24,9 +49,12 @@ def main():
             src = Path(values['SRC'])
             dst = Path(values['DST'])
             process(src, dst, window)
+        if event == 'Settings':
+            show_settings()
 
     window.close()
 
 
 if __name__ == '__main__':
     main()
+

--- a/mp3organizer/report.py
+++ b/mp3organizer/report.py
@@ -6,12 +6,26 @@ def write_html_report(entries, out_path: Path):
     rows = []
     for idx, e in enumerate(entries, 1):
         rows.append(
-            f"<tr><td>{idx}</td><td>{html.escape(e['artist'])}</td><td>{html.escape(e['title'])}</td><td>{e['dest']}</td></tr>"
+            "<tr>"
+            f"<td>{idx}</td>"
+            f"<td>{html.escape(e['artist'])}</td>"
+            f"<td>{html.escape(e['title'])}</td>"
+            f"<td>{html.escape(e['album'])}</td>"
+            f"<td>{html.escape(e['year'])}</td>"
+            f"<td>{html.escape(e['genre'])}</td>"
+            f"<td>{html.escape(e['dest'])}</td>"
+            f"<td><audio controls src='{html.escape(e['path'])}'></audio></td>"
+            "</tr>"
         )
+
     html_content = (
         "<html><body><table border='1'>"
-        "<tr><th>#</th><th>Artist</th><th>Title</th><th>Destination</th></tr>"
+        "<tr>"
+        "<th>#</th><th>Artist</th><th>Title</th><th>Album</th><th>Year</th>"
+        "<th>Genre</th><th>Destination</th><th>Preview</th>"
+        "</tr>"
         f"{''.join(rows)}" "</table></body></html>"
     )
-    with open(out_path, 'w', encoding='utf-8') as f:
+
+    with open(out_path, "w", encoding="utf-8") as f:
         f.write(html_content)

--- a/mp3organizer/spotify.py
+++ b/mp3organizer/spotify.py
@@ -3,14 +3,32 @@ from spotipy import Spotify, SpotifyOAuth
 from spotipy.exceptions import SpotifyException
 from fuzzywuzzy import fuzz
 
-from .utils import CACHE_DIR
+import os
+
+from .utils import CACHE_DIR, load_config
 
 
 MAX_PLAYLIST_SIZE = 10000
 
 
 def get_client():
-    return Spotify(auth_manager=SpotifyOAuth(scope="playlist-modify-public", cache_path=str(CACHE_DIR / "spotify")))
+    cid = os.getenv("SPOTIPY_CLIENT_ID")
+    secret = os.getenv("SPOTIPY_CLIENT_SECRET")
+    redirect = os.getenv("SPOTIPY_REDIRECT_URI")
+    if not (cid and secret and redirect):
+        cfg = load_config()
+        cid = cid or cfg.get("SPOTIPY_CLIENT_ID")
+        secret = secret or cfg.get("SPOTIPY_CLIENT_SECRET")
+        redirect = redirect or cfg.get("SPOTIPY_REDIRECT_URI")
+    return Spotify(
+        auth_manager=SpotifyOAuth(
+            client_id=cid,
+            client_secret=secret,
+            redirect_uri=redirect,
+            scope="playlist-modify-public",
+            cache_path=str(CACHE_DIR / "spotify"),
+        )
+    )
 
 
 def spotify_request(func, *args, on_wait=None, **kwargs):

--- a/mp3organizer/utils.py
+++ b/mp3organizer/utils.py
@@ -5,6 +5,7 @@ from pathlib import Path
 CACHE_DIR = Path(os.path.expanduser("~")) / ".cache_mp3"
 CACHE_DIR.mkdir(exist_ok=True)
 CACHE_FILE = CACHE_DIR / "cache.json"
+CONFIG_PATH = Path(os.path.expanduser("~")) / ".mp3organizer_config"
 
 
 def load_cache():
@@ -19,5 +20,18 @@ def save_cache(cache):
         json.dump(cache, f)
 
 
+def load_config() -> dict:
+    if CONFIG_PATH.exists():
+        with open(CONFIG_PATH, "r", encoding="utf-8") as f:
+            return json.load(f)
+    return {}
+
+
+def save_config(cfg: dict) -> None:
+    with open(CONFIG_PATH, "w", encoding="utf-8") as f:
+        json.dump(cfg, f)
+
+
 def sanitize_filename(name: str) -> str:
     return ''.join(c for c in name if c.isalnum() or c in (' ', '-', '_')).title()
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ fuzzywuzzy>=0.18.0
 python-Levenshtein>=0.12.2
 PySimpleGUI>=4.60.5
 requests>=2.28.2
+pytest>=7.4
+

--- a/tests/test_spotify.py
+++ b/tests/test_spotify.py
@@ -1,0 +1,46 @@
+import mp3organizer.spotify as spotify
+
+class DummySp:
+    def __init__(self):
+        self.created = []
+        self.added = []
+        self.counter = 0
+
+    def user_playlist_create(self, user_id, name, **_):
+        self.counter += 1
+        pid = f"id_{self.counter}"
+        self.created.append((user_id, name))
+        return {"id": pid, "name": name}
+
+    def playlist_add_items(self, playlist_id, items, **_):
+        self.added.append((playlist_id, items))
+        return {}
+
+def passthrough(func, *args, **kwargs):
+    return func(*args, **kwargs)
+
+
+def test_add_to_playlist_split(monkeypatch):
+    sp = DummySp()
+    playlists = [{"id": "p1", "name": "Spotify", "count": spotify.MAX_PLAYLIST_SIZE}]
+    monkeypatch.setattr(spotify, "spotify_request", passthrough)
+
+    spotify.add_to_playlist(sp, playlists, "uid", "Spotify", "track1")
+
+    assert len(playlists) == 2
+    assert playlists[-1]["count"] == 1
+    assert sp.created == [("uid", "Spotify 2")]
+    assert sp.added == [("id_1", ["track1"])]
+
+
+def test_add_to_playlist_no_split(monkeypatch):
+    sp = DummySp()
+    playlists = [{"id": "p1", "name": "Spotify", "count": 5}]
+    monkeypatch.setattr(spotify, "spotify_request", passthrough)
+
+    spotify.add_to_playlist(sp, playlists, "uid", "Spotify", "track2")
+
+    assert len(playlists) == 1
+    assert playlists[0]["count"] == 6
+    assert sp.created == []
+    assert sp.added == [("p1", ["track2"])]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,26 @@
+import json
+from pathlib import Path
+import mp3organizer.utils as utils
+
+
+def test_sanitize_filename():
+    assert utils.sanitize_filename('test! file@name') == 'Test Filename'
+    assert utils.sanitize_filename('hello_world-123') == 'Hello_World-123'
+
+
+def test_load_save_cache(tmp_path, monkeypatch):
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+    cache_file = cache_dir / "cache.json"
+    monkeypatch.setattr(utils, "CACHE_DIR", cache_dir)
+    monkeypatch.setattr(utils, "CACHE_FILE", cache_file)
+
+    # Loading when file does not exist returns empty dict
+    assert utils.load_cache() == {}
+
+    data = {"a": 1, "b": 2}
+    utils.save_cache(data)
+    assert cache_file.exists()
+
+    loaded = utils.load_cache()
+    assert loaded == data


### PR DESCRIPTION
## Summary
- extend HTML report with album, year, genre and inline audio player
- pass metadata and relative file path from `core.process`
- document the new report features

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_687537b46b10832dbbf0c6bf2db2c7ae