### PR TITLE
Add settings dialog and config file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The application uses a dark themed PySimpleGUI interface and can be turned into 
    ```bash
    pip install -r requirements.txt
    ```
-2. Provide API credentials via environment variables:
+2. Provide API credentials via environment variables or the GUI settings dialog:
    - `SPOTIPY_CLIENT_ID`
    - `SPOTIPY_CLIENT_SECRET`
    - `SPOTIPY_REDIRECT_URI`
@@ -20,6 +20,8 @@ The application uses a dark themed PySimpleGUI interface and can be turned into 
    ```bash
    python src/main.py
    ```
+   Use the **Settings** button in the GUI to enter credentials if you have not
+   set the environment variables. Values are saved to `~/.mp3organizer_config`.
 
 To build a standalone executable on Windows:
 ```bash

--- a/mp3organizer/audd.py
+++ b/mp3organizer/audd.py
@@ -1,9 +1,18 @@
+import os
 import requests
 
+from .utils import load_config
 
-def recognize(path: str, api_key: str):
-    files = {'file': open(path, 'rb')}
-    data = {'api_token': api_key}
+
+def recognize(path: str, api_key: str | None = None):
+    api_key = api_key or os.getenv("AUDD_API_KEY")
+    if not api_key:
+        cfg = load_config()
+        api_key = cfg.get("AUDD_API_KEY")
+    if not api_key:
+        return None, None
+    files = {"file": open(path, "rb")}
+    data = {"api_token": api_key}
     r = requests.post('https://api.audd.io/', data=data, files=files)
     if r.status_code == 200:
         result = r.json().get('result')

--- a/mp3organizer/core.py
+++ b/mp3organizer/core.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 from typing import Optional
 
@@ -72,22 +71,20 @@ def process(src: Path, dst: Path, window: Optional[object] = None):
             if not match:
                 match = fuzzy_search(sp, cache, f'{artist} {title}', on_wait=on_wait)
         if not match:
-            api_key = os.getenv('AUDD_API_KEY')
-            if api_key:
-                ra, rt = recognize(str(file), api_key)
-                if ra and rt:
-                    match = search(sp, cache, ra, rt, on_wait=on_wait)
-                    if not match:
-                        match = fuzzy_search(sp, cache, f'{ra} {rt}', on_wait=on_wait)
-                    artist = ra
-                    title = rt
-                    try:
-                        tags = EasyID3(file)
-                    except ID3NoHeaderError:
-                        tags = EasyID3()
-                    tags['artist'] = artist.title()
-                    tags['title'] = title.title()
-                    tags.save(file)
+            ra, rt = recognize(str(file))
+            if ra and rt:
+                match = search(sp, cache, ra, rt, on_wait=on_wait)
+                if not match:
+                    match = fuzzy_search(sp, cache, f'{ra} {rt}', on_wait=on_wait)
+                artist = ra
+                title = rt
+                try:
+                    tags = EasyID3(file)
+                except ID3NoHeaderError:
+                    tags = EasyID3()
+                tags['artist'] = artist.title()
+                tags['title'] = title.title()
+                tags.save(file)
 
         if match:
             track_id = match['id']
@@ -111,3 +108,4 @@ def process(src: Path, dst: Path, window: Optional[object] = None):
 
     write_html_report(entries, dst / 'report.html')
     save_cache(cache)
+

--- a/mp3organizer/gui.py
+++ b/mp3organizer/gui.py
@@ -2,6 +2,7 @@ from pathlib import Path
 import PySimpleGUI as sg
 
 from .core import process
+from .utils import load_config, save_config
 
 
 def main():
@@ -9,12 +10,36 @@ def main():
     layout = [
         [sg.Text('Source Folder'), sg.Input(key='SRC'), sg.FolderBrowse()],
         [sg.Text('Output Folder'), sg.Input(key='DST'), sg.FolderBrowse()],
-        [sg.Button('Start')],
+        [sg.Button('Start'), sg.Button('Settings')],
         [sg.ProgressBar(max_value=1, orientation='h', size=(40, 20), key='PROG')],
         [sg.Text('', size=(60, 1), key='STATUS')],
     ]
 
     window = sg.Window('MP3 Organizer', layout, finalize=True)
+
+    def show_settings():
+        cfg = load_config()
+        layout = [
+            [sg.Text('SPOTIPY_CLIENT_ID'), sg.Input(cfg.get('SPOTIPY_CLIENT_ID', ''), key='CID')],
+            [sg.Text('SPOTIPY_CLIENT_SECRET'), sg.Input(cfg.get('SPOTIPY_CLIENT_SECRET', ''), key='SECRET')],
+            [sg.Text('SPOTIPY_REDIRECT_URI'), sg.Input(cfg.get('SPOTIPY_REDIRECT_URI', ''), key='REDIRECT')],
+            [sg.Text('AUDD_API_KEY'), sg.Input(cfg.get('AUDD_API_KEY', ''), key='AUDD')],
+            [sg.Button('Save'), sg.Button('Cancel')],
+        ]
+        win = sg.Window('Settings', layout, modal=True)
+        while True:
+            e, v = win.read()
+            if e in (sg.WIN_CLOSED, 'Cancel'):
+                break
+            if e == 'Save':
+                save_config({
+                    'SPOTIPY_CLIENT_ID': v['CID'],
+                    'SPOTIPY_CLIENT_SECRET': v['SECRET'],
+                    'SPOTIPY_REDIRECT_URI': v['REDIRECT'],
+                    'AUDD_API_KEY': v['AUDD'],
+                })
+                break
+        win.close()
 
     while True:
         event, values = window.read()
@@ -24,9 +49,12 @@ def main():
             src = Path(values['SRC'])
             dst = Path(values['DST'])
             process(src, dst, window)
+        if event == 'Settings':
+            show_settings()
 
     window.close()
 
 
 if __name__ == '__main__':
     main()
+

--- a/mp3organizer/spotify.py
+++ b/mp3organizer/spotify.py
@@ -3,14 +3,32 @@ from spotipy import Spotify, SpotifyOAuth
 from spotipy.exceptions import SpotifyException
 from fuzzywuzzy import fuzz
 
-from .utils import CACHE_DIR
+import os
+
+from .utils import CACHE_DIR, load_config
 
 
 MAX_PLAYLIST_SIZE = 10000
 
 
 def get_client():
-    return Spotify(auth_manager=SpotifyOAuth(scope="playlist-modify-public", cache_path=str(CACHE_DIR / "spotify")))
+    cid = os.getenv("SPOTIPY_CLIENT_ID")
+    secret = os.getenv("SPOTIPY_CLIENT_SECRET")
+    redirect = os.getenv("SPOTIPY_REDIRECT_URI")
+    if not (cid and secret and redirect):
+        cfg = load_config()
+        cid = cid or cfg.get("SPOTIPY_CLIENT_ID")
+        secret = secret or cfg.get("SPOTIPY_CLIENT_SECRET")
+        redirect = redirect or cfg.get("SPOTIPY_REDIRECT_URI")
+    return Spotify(
+        auth_manager=SpotifyOAuth(
+            client_id=cid,
+            client_secret=secret,
+            redirect_uri=redirect,
+            scope="playlist-modify-public",
+            cache_path=str(CACHE_DIR / "spotify"),
+        )
+    )
 
 
 def spotify_request(func, *args, on_wait=None, **kwargs):

--- a/mp3organizer/utils.py
+++ b/mp3organizer/utils.py
@@ -5,6 +5,7 @@ from pathlib import Path
 CACHE_DIR = Path(os.path.expanduser("~")) / ".cache_mp3"
 CACHE_DIR.mkdir(exist_ok=True)
 CACHE_FILE = CACHE_DIR / "cache.json"
+CONFIG_PATH = Path(os.path.expanduser("~")) / ".mp3organizer_config"
 
 
 def load_cache():
@@ -19,5 +20,18 @@ def save_cache(cache):
         json.dump(cache, f)
 
 
+def load_config() -> dict:
+    if CONFIG_PATH.exists():
+        with open(CONFIG_PATH, "r", encoding="utf-8") as f:
+            return json.load(f)
+    return {}
+
+
+def save_config(cfg: dict) -> None:
+    with open(CONFIG_PATH, "w", encoding="utf-8") as f:
+        json.dump(cfg, f)
+
+
 def sanitize_filename(name: str) -> str:
     return ''.join(c for c in name if c.isalnum() or c in (' ', '-', '_')).title()
+


### PR DESCRIPTION
## Summary
- add JSON config file helpers
- support loading credentials from config in Spotify and audD helpers
- integrate a Settings dialog in the GUI
- update README with new instructions

## Testing
- `python -m compileall -q mp3organizer src`

------
https://chatgpt.com/codex/tasks/task_e_6875368b2314832d941bc00badb3e3c4